### PR TITLE
Wire UIKIT and BLOC

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/widgets.dart';
+
+class Constants {
+  static const Curve basicAnimationCurve = Curves.easeInOutCubic;
+  static const Duration basicAnimationDuration = Duration(milliseconds: 400);
+}

--- a/lib/core/di/di.config.dart
+++ b/lib/core/di/di.config.dart
@@ -28,8 +28,6 @@ import 'package:rsvp_flutter_app/features/file_picking/domain/usecases/import_bo
     as _i749;
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart'
     as _i422;
-import 'package:rsvp_flutter_app/features/rsvp_reading/presentation/bloc/reading_bloc.dart'
-    as _i76;
 import 'package:rsvp_flutter_app/services/book_converter.dart' as _i216;
 import 'package:rsvp_flutter_app/services/cache_service.dart' as _i332;
 import 'package:rsvp_flutter_app/services/pdf_parser.dart' as _i500;
@@ -49,19 +47,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.singleton<_i51.FilePickerDataSource>(() => _i51.FilePickerDataSource());
     gh.singleton<_i303.FileLoaderService>(() => _i303.FileLoaderService());
     gh.singleton<_i332.CacheService>(() => _i332.CacheService());
-    gh.singleton<_i1019.TextProcessor>(() => _i1019.TextProcessor());
     gh.lazySingleton<_i500.PdfParser>(() => _i500.PdfParser());
+    gh.lazySingleton<_i1019.TextProcessor>(() => _i1019.TextProcessor());
     gh.lazySingleton<_i91.TxtParser>(() => _i91.TxtParser());
-    gh.singleton<_i177.BookDbService>(
-      () => _i177.BookDbService(gh<_i174.AppDatabase>()),
-    );
-    gh.singleton<_i216.BookConverter>(
-      () => _i216.BookConverter(
-        gh<_i500.PdfParser>(),
-        gh<_i91.TxtParser>(),
-        gh<_i1019.TextProcessor>(),
-      ),
-    );
     gh.lazySingleton<_i69.FileRepository>(
       () => _i542.FileRepositoryImpl(
         gh<_i303.FileLoaderService>(),
@@ -72,6 +60,13 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.singleton<_i749.ImportBookFile>(
       () => _i749.ImportBookFile(gh<_i69.FileRepository>()),
+    );
+    gh.singleton<_i216.BookConverter>(
+      () => _i216.BookConverter(
+        gh<_i500.PdfParser>(),
+        gh<_i91.TxtParser>(),
+        gh<_i1019.TextProcessor>(),
+      ),
     );
     gh.factory<_i422.RsvpBloc>(
       () => _i422.RsvpBloc(

--- a/lib/core/di/di.config.dart
+++ b/lib/core/di/di.config.dart
@@ -28,6 +28,8 @@ import 'package:rsvp_flutter_app/features/file_picking/domain/usecases/import_bo
     as _i749;
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart'
     as _i422;
+import 'package:rsvp_flutter_app/features/rsvp_reading/presentation/bloc/reading_bloc.dart'
+    as _i76;
 import 'package:rsvp_flutter_app/services/book_converter.dart' as _i216;
 import 'package:rsvp_flutter_app/services/cache_service.dart' as _i332;
 import 'package:rsvp_flutter_app/services/pdf_parser.dart' as _i500;
@@ -47,9 +49,19 @@ extension GetItInjectableX on _i174.GetIt {
     gh.singleton<_i51.FilePickerDataSource>(() => _i51.FilePickerDataSource());
     gh.singleton<_i303.FileLoaderService>(() => _i303.FileLoaderService());
     gh.singleton<_i332.CacheService>(() => _i332.CacheService());
+    gh.singleton<_i1019.TextProcessor>(() => _i1019.TextProcessor());
     gh.lazySingleton<_i500.PdfParser>(() => _i500.PdfParser());
-    gh.lazySingleton<_i1019.TextProcessor>(() => _i1019.TextProcessor());
     gh.lazySingleton<_i91.TxtParser>(() => _i91.TxtParser());
+    gh.singleton<_i177.BookDbService>(
+      () => _i177.BookDbService(gh<_i174.AppDatabase>()),
+    );
+    gh.singleton<_i216.BookConverter>(
+      () => _i216.BookConverter(
+        gh<_i500.PdfParser>(),
+        gh<_i91.TxtParser>(),
+        gh<_i1019.TextProcessor>(),
+      ),
+    );
     gh.lazySingleton<_i69.FileRepository>(
       () => _i542.FileRepositoryImpl(
         gh<_i303.FileLoaderService>(),
@@ -60,13 +72,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.singleton<_i749.ImportBookFile>(
       () => _i749.ImportBookFile(gh<_i69.FileRepository>()),
-    );
-    gh.singleton<_i216.BookConverter>(
-      () => _i216.BookConverter(
-        gh<_i500.PdfParser>(),
-        gh<_i91.TxtParser>(),
-        gh<_i1019.TextProcessor>(),
-      ),
     );
     gh.factory<_i422.RsvpBloc>(
       () => _i422.RsvpBloc(

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart
@@ -24,6 +24,8 @@ class RsvpBloc extends Bloc<RsvpEvent, RsvpState> {
        super(const _RsvpState()) {
     on<_Started>(_onStarted);
     on<_AddBook>(_onAddBook);
+    on<_ToggleSelectBook>(_onToggleSelectBook);
+    on<_StartAnimation>(_onStartAnimation);
   }
 
   final FileRepository _fileRepository;
@@ -72,6 +74,11 @@ class RsvpBloc extends Bloc<RsvpEvent, RsvpState> {
       logger.e(e);
       emit(state.copyWith(lastError: RSVPError.parsingError(error: e)));
     }
+  }
+
+  void _onToggleSelectBook(_ToggleSelectBook event, Emitter<RsvpState> emit) {
+    final selectedBook = state.selectedBook == event.book ? null : event.book;
+    emit(state.copyWith(selectedBook: selectedBook));
   }
 
   void _onStartAnimation(_StartAnimation event, Emitter<RsvpState> emit) {

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart
@@ -15,13 +15,13 @@ part 'rsvp_event.dart';
 part 'rsvp_state.dart';
 
 @injectable
-class RsvpBloc extends Bloc<RsvpBlocEvent, RsvpBlocState> {
+class RsvpBloc extends Bloc<RsvpEvent, RsvpState> {
   RsvpBloc({
     required FileRepository fileRepository,
     required BookConverter bookConverter,
   }) : _fileRepository = fileRepository,
        _bookConverter = bookConverter,
-       super(const RsvpBlocState()) {
+       super(const _RsvpState()) {
     on<_Started>(_onStarted);
     on<_AddBook>(_onAddBook);
   }
@@ -29,15 +29,13 @@ class RsvpBloc extends Bloc<RsvpBlocEvent, RsvpBlocState> {
   final FileRepository _fileRepository;
   final BookConverter _bookConverter;
 
-  void _onStarted(_Started event, Emitter<RsvpBlocState> emit) {
-    emit(const RsvpBlocState());
-  }
+  void _onStarted(_Started event, Emitter<RsvpState> emit) {}
 
-  Future<void> _onAddBook(_AddBook event, Emitter<RsvpBlocState> emit) async {
+  Future<void> _onAddBook(_AddBook event, Emitter<RsvpState> emit) async {
     emit(
       state.copyWith(
         isParsing: true,
-        lastParsingError: null,
+        lastError: null,
         selectedBook: null,
       ),
     );
@@ -47,7 +45,7 @@ class RsvpBloc extends Bloc<RsvpBlocEvent, RsvpBlocState> {
       bookFile = await _fileRepository.pickAndLoadFile();
     } on Exception catch (e) {
       logger.e(e);
-      emit(state.copyWith(lastParsingError: RSVPError.parsingError(error: e)));
+      emit(state.copyWith(lastError: RSVPError.parsingError(error: e)));
       return;
     }
 
@@ -67,15 +65,16 @@ class RsvpBloc extends Bloc<RsvpBlocEvent, RsvpBlocState> {
           index: index,
         ),
       );
-      emit(
-        state.copyWith(
-          selectedBook: BookMetaModel(bookFile: bookFile, tokens: tokens),
-        ),
-      );
+      final books = List<BookMetaModel>.from(state.books)..add(BookMetaModel(bookFile: bookFile, tokens: tokens));
+      emit(state.copyWith(books: books));
       logger.d('File is successfully parsed.');
     } on Exception catch (e) {
       logger.e(e);
-      emit(state.copyWith(lastParsingError: RSVPError.parsingError(error: e)));
+      emit(state.copyWith(lastError: RSVPError.parsingError(error: e)));
     }
+  }
+
+  void _onStartAnimation(_StartAnimation event, Emitter<RsvpState> emit) {
+    // Either simply emit new state with animationShouldStartPlaying = true
   }
 }

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.freezed.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.freezed.dart
@@ -55,12 +55,13 @@ extension RsvpEventPatterns on RsvpEvent {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _Started value)?  started,TResult Function( _AddBook value)?  addBook,TResult Function( _StartAnimation value)?  startAnimation,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _Started value)?  started,TResult Function( _AddBook value)?  addBook,TResult Function( _ToggleSelectBook value)?  toggleSelectBook,TResult Function( _StartAnimation value)?  startAnimation,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case _Started() when started != null:
 return started(_that);case _AddBook() when addBook != null:
-return addBook(_that);case _StartAnimation() when startAnimation != null:
+return addBook(_that);case _ToggleSelectBook() when toggleSelectBook != null:
+return toggleSelectBook(_that);case _StartAnimation() when startAnimation != null:
 return startAnimation(_that);case _:
   return orElse();
 
@@ -79,12 +80,13 @@ return startAnimation(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _Started value)  started,required TResult Function( _AddBook value)  addBook,required TResult Function( _StartAnimation value)  startAnimation,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _Started value)  started,required TResult Function( _AddBook value)  addBook,required TResult Function( _ToggleSelectBook value)  toggleSelectBook,required TResult Function( _StartAnimation value)  startAnimation,}){
 final _that = this;
 switch (_that) {
 case _Started():
 return started(_that);case _AddBook():
-return addBook(_that);case _StartAnimation():
+return addBook(_that);case _ToggleSelectBook():
+return toggleSelectBook(_that);case _StartAnimation():
 return startAnimation(_that);case _:
   throw StateError('Unexpected subclass');
 
@@ -102,12 +104,13 @@ return startAnimation(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _Started value)?  started,TResult? Function( _AddBook value)?  addBook,TResult? Function( _StartAnimation value)?  startAnimation,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _Started value)?  started,TResult? Function( _AddBook value)?  addBook,TResult? Function( _ToggleSelectBook value)?  toggleSelectBook,TResult? Function( _StartAnimation value)?  startAnimation,}){
 final _that = this;
 switch (_that) {
 case _Started() when started != null:
 return started(_that);case _AddBook() when addBook != null:
-return addBook(_that);case _StartAnimation() when startAnimation != null:
+return addBook(_that);case _ToggleSelectBook() when toggleSelectBook != null:
+return toggleSelectBook(_that);case _StartAnimation() when startAnimation != null:
 return startAnimation(_that);case _:
   return null;
 
@@ -125,11 +128,12 @@ return startAnimation(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  started,TResult Function()?  addBook,TResult Function( int bookID)?  startAnimation,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  started,TResult Function()?  addBook,TResult Function( BookMetaModel book)?  toggleSelectBook,TResult Function( int bookID)?  startAnimation,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Started() when started != null:
 return started();case _AddBook() when addBook != null:
-return addBook();case _StartAnimation() when startAnimation != null:
+return addBook();case _ToggleSelectBook() when toggleSelectBook != null:
+return toggleSelectBook(_that.book);case _StartAnimation() when startAnimation != null:
 return startAnimation(_that.bookID);case _:
   return orElse();
 
@@ -148,11 +152,12 @@ return startAnimation(_that.bookID);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  started,required TResult Function()  addBook,required TResult Function( int bookID)  startAnimation,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  started,required TResult Function()  addBook,required TResult Function( BookMetaModel book)  toggleSelectBook,required TResult Function( int bookID)  startAnimation,}) {final _that = this;
 switch (_that) {
 case _Started():
 return started();case _AddBook():
-return addBook();case _StartAnimation():
+return addBook();case _ToggleSelectBook():
+return toggleSelectBook(_that.book);case _StartAnimation():
 return startAnimation(_that.bookID);case _:
   throw StateError('Unexpected subclass');
 
@@ -170,11 +175,12 @@ return startAnimation(_that.bookID);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  started,TResult? Function()?  addBook,TResult? Function( int bookID)?  startAnimation,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  started,TResult? Function()?  addBook,TResult? Function( BookMetaModel book)?  toggleSelectBook,TResult? Function( int bookID)?  startAnimation,}) {final _that = this;
 switch (_that) {
 case _Started() when started != null:
 return started();case _AddBook() when addBook != null:
-return addBook();case _StartAnimation() when startAnimation != null:
+return addBook();case _ToggleSelectBook() when toggleSelectBook != null:
+return toggleSelectBook(_that.book);case _StartAnimation() when startAnimation != null:
 return startAnimation(_that.bookID);case _:
   return null;
 
@@ -246,6 +252,81 @@ String toString() {
 
 
 
+
+/// @nodoc
+
+
+class _ToggleSelectBook implements RsvpEvent {
+  const _ToggleSelectBook({required this.book});
+  
+
+ final  BookMetaModel book;
+
+/// Create a copy of RsvpEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ToggleSelectBookCopyWith<_ToggleSelectBook> get copyWith => __$ToggleSelectBookCopyWithImpl<_ToggleSelectBook>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ToggleSelectBook&&(identical(other.book, book) || other.book == book));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,book);
+
+@override
+String toString() {
+  return 'RsvpEvent.toggleSelectBook(book: $book)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ToggleSelectBookCopyWith<$Res> implements $RsvpEventCopyWith<$Res> {
+  factory _$ToggleSelectBookCopyWith(_ToggleSelectBook value, $Res Function(_ToggleSelectBook) _then) = __$ToggleSelectBookCopyWithImpl;
+@useResult
+$Res call({
+ BookMetaModel book
+});
+
+
+$BookMetaModelCopyWith<$Res> get book;
+
+}
+/// @nodoc
+class __$ToggleSelectBookCopyWithImpl<$Res>
+    implements _$ToggleSelectBookCopyWith<$Res> {
+  __$ToggleSelectBookCopyWithImpl(this._self, this._then);
+
+  final _ToggleSelectBook _self;
+  final $Res Function(_ToggleSelectBook) _then;
+
+/// Create a copy of RsvpEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? book = null,}) {
+  return _then(_ToggleSelectBook(
+book: null == book ? _self.book : book // ignore: cast_nullable_to_non_nullable
+as BookMetaModel,
+  ));
+}
+
+/// Create a copy of RsvpEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BookMetaModelCopyWith<$Res> get book {
+  
+  return $BookMetaModelCopyWith<$Res>(_self.book, (value) {
+    return _then(_self.copyWith(book: value));
+  });
+}
+}
 
 /// @nodoc
 

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.freezed.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.freezed.dart
@@ -12,7 +12,7 @@ part of 'rsvp_bloc.dart';
 // dart format off
 T _$identity<T>(T value) => value;
 /// @nodoc
-mixin _$RsvpBlocEvent {
+mixin _$RsvpEvent {
 
 
 
@@ -20,7 +20,7 @@ mixin _$RsvpBlocEvent {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsvpBlocEvent);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsvpEvent);
 }
 
 
@@ -29,20 +29,20 @@ int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'RsvpBlocEvent()';
+  return 'RsvpEvent()';
 }
 
 
 }
 
 /// @nodoc
-class $RsvpBlocEventCopyWith<$Res>  {
-$RsvpBlocEventCopyWith(RsvpBlocEvent _, $Res Function(RsvpBlocEvent) __);
+class $RsvpEventCopyWith<$Res>  {
+$RsvpEventCopyWith(RsvpEvent _, $Res Function(RsvpEvent) __);
 }
 
 
-/// Adds pattern-matching-related methods to [RsvpBlocEvent].
-extension RsvpBlocEventPatterns on RsvpBlocEvent {
+/// Adds pattern-matching-related methods to [RsvpEvent].
+extension RsvpEventPatterns on RsvpEvent {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:
@@ -186,7 +186,7 @@ return startAnimation(_that.bookID);case _:
 /// @nodoc
 
 
-class _Started implements RsvpBlocEvent {
+class _Started implements RsvpEvent {
   const _Started();
   
 
@@ -206,7 +206,7 @@ int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'RsvpBlocEvent.started()';
+  return 'RsvpEvent.started()';
 }
 
 
@@ -218,7 +218,7 @@ String toString() {
 /// @nodoc
 
 
-class _AddBook implements RsvpBlocEvent {
+class _AddBook implements RsvpEvent {
   const _AddBook();
   
 
@@ -238,7 +238,7 @@ int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'RsvpBlocEvent.addBook()';
+  return 'RsvpEvent.addBook()';
 }
 
 
@@ -250,13 +250,13 @@ String toString() {
 /// @nodoc
 
 
-class _StartAnimation implements RsvpBlocEvent {
+class _StartAnimation implements RsvpEvent {
   const _StartAnimation({required this.bookID});
   
 
  final  int bookID;
 
-/// Create a copy of RsvpBlocEvent
+/// Create a copy of RsvpEvent
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
@@ -275,14 +275,14 @@ int get hashCode => Object.hash(runtimeType,bookID);
 
 @override
 String toString() {
-  return 'RsvpBlocEvent.startAnimation(bookID: $bookID)';
+  return 'RsvpEvent.startAnimation(bookID: $bookID)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class _$StartAnimationCopyWith<$Res> implements $RsvpBlocEventCopyWith<$Res> {
+abstract mixin class _$StartAnimationCopyWith<$Res> implements $RsvpEventCopyWith<$Res> {
   factory _$StartAnimationCopyWith(_StartAnimation value, $Res Function(_StartAnimation) _then) = __$StartAnimationCopyWithImpl;
 @useResult
 $Res call({
@@ -301,7 +301,7 @@ class __$StartAnimationCopyWithImpl<$Res>
   final _StartAnimation _self;
   final $Res Function(_StartAnimation) _then;
 
-/// Create a copy of RsvpBlocEvent
+/// Create a copy of RsvpEvent
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? bookID = null,}) {
   return _then(_StartAnimation(
@@ -314,65 +314,66 @@ as int,
 }
 
 /// @nodoc
-mixin _$RsvpBlocState {
+mixin _$RsvpState {
 
- BookMetaModel? get selectedBook; bool get isParsing; RSVPError? get lastParsingError;
-/// Create a copy of RsvpBlocState
+ BookMetaModel? get selectedBook; bool get isParsing; RSVPError? get lastError; List<BookMetaModel> get books;
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-$RsvpBlocStateCopyWith<RsvpBlocState> get copyWith => _$RsvpBlocStateCopyWithImpl<RsvpBlocState>(this as RsvpBlocState, _$identity);
+$RsvpStateCopyWith<RsvpState> get copyWith => _$RsvpStateCopyWithImpl<RsvpState>(this as RsvpState, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsvpBlocState&&(identical(other.selectedBook, selectedBook) || other.selectedBook == selectedBook)&&(identical(other.isParsing, isParsing) || other.isParsing == isParsing)&&(identical(other.lastParsingError, lastParsingError) || other.lastParsingError == lastParsingError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RsvpState&&(identical(other.selectedBook, selectedBook) || other.selectedBook == selectedBook)&&(identical(other.isParsing, isParsing) || other.isParsing == isParsing)&&(identical(other.lastError, lastError) || other.lastError == lastError)&&const DeepCollectionEquality().equals(other.books, books));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,selectedBook,isParsing,lastParsingError);
+int get hashCode => Object.hash(runtimeType,selectedBook,isParsing,lastError,const DeepCollectionEquality().hash(books));
 
 @override
 String toString() {
-  return 'RsvpBlocState(selectedBook: $selectedBook, isParsing: $isParsing, lastParsingError: $lastParsingError)';
+  return 'RsvpState(selectedBook: $selectedBook, isParsing: $isParsing, lastError: $lastError, books: $books)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $RsvpBlocStateCopyWith<$Res>  {
-  factory $RsvpBlocStateCopyWith(RsvpBlocState value, $Res Function(RsvpBlocState) _then) = _$RsvpBlocStateCopyWithImpl;
+abstract mixin class $RsvpStateCopyWith<$Res>  {
+  factory $RsvpStateCopyWith(RsvpState value, $Res Function(RsvpState) _then) = _$RsvpStateCopyWithImpl;
 @useResult
 $Res call({
- BookMetaModel? selectedBook, bool isParsing, RSVPError? lastParsingError
+ BookMetaModel? selectedBook, bool isParsing, RSVPError? lastError, List<BookMetaModel> books
 });
 
 
-$BookMetaModelCopyWith<$Res>? get selectedBook;$RSVPErrorCopyWith<$Res>? get lastParsingError;
+$BookMetaModelCopyWith<$Res>? get selectedBook;$RSVPErrorCopyWith<$Res>? get lastError;
 
 }
 /// @nodoc
-class _$RsvpBlocStateCopyWithImpl<$Res>
-    implements $RsvpBlocStateCopyWith<$Res> {
-  _$RsvpBlocStateCopyWithImpl(this._self, this._then);
+class _$RsvpStateCopyWithImpl<$Res>
+    implements $RsvpStateCopyWith<$Res> {
+  _$RsvpStateCopyWithImpl(this._self, this._then);
 
-  final RsvpBlocState _self;
-  final $Res Function(RsvpBlocState) _then;
+  final RsvpState _self;
+  final $Res Function(RsvpState) _then;
 
-/// Create a copy of RsvpBlocState
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? selectedBook = freezed,Object? isParsing = null,Object? lastParsingError = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? selectedBook = freezed,Object? isParsing = null,Object? lastError = freezed,Object? books = null,}) {
   return _then(_self.copyWith(
 selectedBook: freezed == selectedBook ? _self.selectedBook : selectedBook // ignore: cast_nullable_to_non_nullable
 as BookMetaModel?,isParsing: null == isParsing ? _self.isParsing : isParsing // ignore: cast_nullable_to_non_nullable
-as bool,lastParsingError: freezed == lastParsingError ? _self.lastParsingError : lastParsingError // ignore: cast_nullable_to_non_nullable
-as RSVPError?,
+as bool,lastError: freezed == lastError ? _self.lastError : lastError // ignore: cast_nullable_to_non_nullable
+as RSVPError?,books: null == books ? _self.books : books // ignore: cast_nullable_to_non_nullable
+as List<BookMetaModel>,
   ));
 }
-/// Create a copy of RsvpBlocState
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
@@ -384,24 +385,24 @@ $BookMetaModelCopyWith<$Res>? get selectedBook {
   return $BookMetaModelCopyWith<$Res>(_self.selectedBook!, (value) {
     return _then(_self.copyWith(selectedBook: value));
   });
-}/// Create a copy of RsvpBlocState
+}/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$RSVPErrorCopyWith<$Res>? get lastParsingError {
-    if (_self.lastParsingError == null) {
+$RSVPErrorCopyWith<$Res>? get lastError {
+    if (_self.lastError == null) {
     return null;
   }
 
-  return $RSVPErrorCopyWith<$Res>(_self.lastParsingError!, (value) {
-    return _then(_self.copyWith(lastParsingError: value));
+  return $RSVPErrorCopyWith<$Res>(_self.lastError!, (value) {
+    return _then(_self.copyWith(lastError: value));
   });
 }
 }
 
 
-/// Adds pattern-matching-related methods to [RsvpBlocState].
-extension RsvpBlocStatePatterns on RsvpBlocState {
+/// Adds pattern-matching-related methods to [RsvpState].
+extension RsvpStatePatterns on RsvpState {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:
@@ -414,10 +415,10 @@ extension RsvpBlocStatePatterns on RsvpBlocState {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RsvpBlocState value)?  $default,{required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RsvpState value)?  $default,{required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case _RsvpBlocState() when $default != null:
+case _RsvpState() when $default != null:
 return $default(_that);case _:
   return orElse();
 
@@ -436,10 +437,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RsvpBlocState value)  $default,){
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RsvpState value)  $default,){
 final _that = this;
 switch (_that) {
-case _RsvpBlocState():
+case _RsvpState():
 return $default(_that);case _:
   throw StateError('Unexpected subclass');
 
@@ -457,10 +458,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RsvpBlocState value)?  $default,){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RsvpState value)?  $default,){
 final _that = this;
 switch (_that) {
-case _RsvpBlocState() when $default != null:
+case _RsvpState() when $default != null:
 return $default(_that);case _:
   return null;
 
@@ -478,10 +479,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastParsingError)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastError,  List<BookMetaModel> books)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case _RsvpBlocState() when $default != null:
-return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case _:
+case _RsvpState() when $default != null:
+return $default(_that.selectedBook,_that.isParsing,_that.lastError,_that.books);case _:
   return orElse();
 
 }
@@ -499,10 +500,10 @@ return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case 
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastParsingError)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastError,  List<BookMetaModel> books)  $default,) {final _that = this;
 switch (_that) {
-case _RsvpBlocState():
-return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case _:
+case _RsvpState():
+return $default(_that.selectedBook,_that.isParsing,_that.lastError,_that.books);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -519,10 +520,10 @@ return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case 
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastParsingError)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( BookMetaModel? selectedBook,  bool isParsing,  RSVPError? lastError,  List<BookMetaModel> books)?  $default,) {final _that = this;
 switch (_that) {
-case _RsvpBlocState() when $default != null:
-return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case _:
+case _RsvpState() when $default != null:
+return $default(_that.selectedBook,_that.isParsing,_that.lastError,_that.books);case _:
   return null;
 
 }
@@ -533,71 +534,79 @@ return $default(_that.selectedBook,_that.isParsing,_that.lastParsingError);case 
 /// @nodoc
 
 
-class _RsvpBlocState implements RsvpBlocState {
-  const _RsvpBlocState({this.selectedBook, this.isParsing = false, this.lastParsingError});
+class _RsvpState implements RsvpState {
+  const _RsvpState({this.selectedBook, this.isParsing = false, this.lastError, final  List<BookMetaModel> books = const []}): _books = books;
   
 
 @override final  BookMetaModel? selectedBook;
 @override@JsonKey() final  bool isParsing;
-@override final  RSVPError? lastParsingError;
+@override final  RSVPError? lastError;
+ final  List<BookMetaModel> _books;
+@override@JsonKey() List<BookMetaModel> get books {
+  if (_books is EqualUnmodifiableListView) return _books;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_books);
+}
 
-/// Create a copy of RsvpBlocState
+
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @override @JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-_$RsvpBlocStateCopyWith<_RsvpBlocState> get copyWith => __$RsvpBlocStateCopyWithImpl<_RsvpBlocState>(this, _$identity);
+_$RsvpStateCopyWith<_RsvpState> get copyWith => __$RsvpStateCopyWithImpl<_RsvpState>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RsvpBlocState&&(identical(other.selectedBook, selectedBook) || other.selectedBook == selectedBook)&&(identical(other.isParsing, isParsing) || other.isParsing == isParsing)&&(identical(other.lastParsingError, lastParsingError) || other.lastParsingError == lastParsingError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RsvpState&&(identical(other.selectedBook, selectedBook) || other.selectedBook == selectedBook)&&(identical(other.isParsing, isParsing) || other.isParsing == isParsing)&&(identical(other.lastError, lastError) || other.lastError == lastError)&&const DeepCollectionEquality().equals(other._books, _books));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,selectedBook,isParsing,lastParsingError);
+int get hashCode => Object.hash(runtimeType,selectedBook,isParsing,lastError,const DeepCollectionEquality().hash(_books));
 
 @override
 String toString() {
-  return 'RsvpBlocState(selectedBook: $selectedBook, isParsing: $isParsing, lastParsingError: $lastParsingError)';
+  return 'RsvpState(selectedBook: $selectedBook, isParsing: $isParsing, lastError: $lastError, books: $books)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class _$RsvpBlocStateCopyWith<$Res> implements $RsvpBlocStateCopyWith<$Res> {
-  factory _$RsvpBlocStateCopyWith(_RsvpBlocState value, $Res Function(_RsvpBlocState) _then) = __$RsvpBlocStateCopyWithImpl;
+abstract mixin class _$RsvpStateCopyWith<$Res> implements $RsvpStateCopyWith<$Res> {
+  factory _$RsvpStateCopyWith(_RsvpState value, $Res Function(_RsvpState) _then) = __$RsvpStateCopyWithImpl;
 @override @useResult
 $Res call({
- BookMetaModel? selectedBook, bool isParsing, RSVPError? lastParsingError
+ BookMetaModel? selectedBook, bool isParsing, RSVPError? lastError, List<BookMetaModel> books
 });
 
 
-@override $BookMetaModelCopyWith<$Res>? get selectedBook;@override $RSVPErrorCopyWith<$Res>? get lastParsingError;
+@override $BookMetaModelCopyWith<$Res>? get selectedBook;@override $RSVPErrorCopyWith<$Res>? get lastError;
 
 }
 /// @nodoc
-class __$RsvpBlocStateCopyWithImpl<$Res>
-    implements _$RsvpBlocStateCopyWith<$Res> {
-  __$RsvpBlocStateCopyWithImpl(this._self, this._then);
+class __$RsvpStateCopyWithImpl<$Res>
+    implements _$RsvpStateCopyWith<$Res> {
+  __$RsvpStateCopyWithImpl(this._self, this._then);
 
-  final _RsvpBlocState _self;
-  final $Res Function(_RsvpBlocState) _then;
+  final _RsvpState _self;
+  final $Res Function(_RsvpState) _then;
 
-/// Create a copy of RsvpBlocState
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? selectedBook = freezed,Object? isParsing = null,Object? lastParsingError = freezed,}) {
-  return _then(_RsvpBlocState(
+@override @pragma('vm:prefer-inline') $Res call({Object? selectedBook = freezed,Object? isParsing = null,Object? lastError = freezed,Object? books = null,}) {
+  return _then(_RsvpState(
 selectedBook: freezed == selectedBook ? _self.selectedBook : selectedBook // ignore: cast_nullable_to_non_nullable
 as BookMetaModel?,isParsing: null == isParsing ? _self.isParsing : isParsing // ignore: cast_nullable_to_non_nullable
-as bool,lastParsingError: freezed == lastParsingError ? _self.lastParsingError : lastParsingError // ignore: cast_nullable_to_non_nullable
-as RSVPError?,
+as bool,lastError: freezed == lastError ? _self.lastError : lastError // ignore: cast_nullable_to_non_nullable
+as RSVPError?,books: null == books ? _self._books : books // ignore: cast_nullable_to_non_nullable
+as List<BookMetaModel>,
   ));
 }
 
-/// Create a copy of RsvpBlocState
+/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
@@ -609,17 +618,17 @@ $BookMetaModelCopyWith<$Res>? get selectedBook {
   return $BookMetaModelCopyWith<$Res>(_self.selectedBook!, (value) {
     return _then(_self.copyWith(selectedBook: value));
   });
-}/// Create a copy of RsvpBlocState
+}/// Create a copy of RsvpState
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$RSVPErrorCopyWith<$Res>? get lastParsingError {
-    if (_self.lastParsingError == null) {
+$RSVPErrorCopyWith<$Res>? get lastError {
+    if (_self.lastError == null) {
     return null;
   }
 
-  return $RSVPErrorCopyWith<$Res>(_self.lastParsingError!, (value) {
-    return _then(_self.copyWith(lastParsingError: value));
+  return $RSVPErrorCopyWith<$Res>(_self.lastError!, (value) {
+    return _then(_self.copyWith(lastError: value));
   });
 }
 }

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_event.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_event.dart
@@ -4,5 +4,6 @@ part of 'rsvp_bloc.dart';
 class RsvpEvent with _$RsvpEvent {
   const factory RsvpEvent.started() = _Started;
   const factory RsvpEvent.addBook() = _AddBook;
+  const factory RsvpEvent.toggleSelectBook({required BookMetaModel book}) = _ToggleSelectBook;
   const factory RsvpEvent.startAnimation({required int bookID}) = _StartAnimation;
 }

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_event.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_event.dart
@@ -1,8 +1,8 @@
 part of 'rsvp_bloc.dart';
 
 @freezed
-class RsvpBlocEvent with _$RsvpBlocEvent {
-  const factory RsvpBlocEvent.started() = _Started;
-  const factory RsvpBlocEvent.addBook() = _AddBook;
-  const factory RsvpBlocEvent.startAnimation({required int bookID}) = _StartAnimation;
+class RsvpEvent with _$RsvpEvent {
+  const factory RsvpEvent.started() = _Started;
+  const factory RsvpEvent.addBook() = _AddBook;
+  const factory RsvpEvent.startAnimation({required int bookID}) = _StartAnimation;
 }

--- a/lib/features/rsvp_engine/presentation/state/bloc/rsvp_state.dart
+++ b/lib/features/rsvp_engine/presentation/state/bloc/rsvp_state.dart
@@ -1,11 +1,13 @@
 part of 'rsvp_bloc.dart';
 
 @freezed
-abstract class RsvpBlocState with _$RsvpBlocState {
-  const factory RsvpBlocState({
+abstract class RsvpState with _$RsvpState {
+  const factory RsvpState({
     BookMetaModel? selectedBook,
     @Default(false) bool isParsing,
 
-    RSVPError? lastParsingError,
-  }) = _RsvpBlocState;
+    RSVPError? lastError,
+
+    @Default([]) List<BookMetaModel> books,
+  }) = _RsvpState;
 }

--- a/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
+++ b/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
@@ -23,6 +23,7 @@ class MainScreen extends StatelessWidget {
           final bookWidgets = state.books
               .map(
                 (b) => BookItem(
+                  onTap: () => context.read<RsvpBloc>().add(RsvpEvent.toggleSelectBook(book: b)),
                   title: b.name ?? 'Unknown',
                   author: 'Unknown',
                   progress: 0.0,

--- a/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
+++ b/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rsvp_flutter_app/core/di/di.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart';
-import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/mock_reading_button.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/new_book_button.dart';
 import 'package:rsvp_flutter_app/features/ui_kit/ui_kit.dart';
 
@@ -11,28 +10,6 @@ class MainScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const state = LibraryMainScreenState.nonEmpty;
-    const bookItems = [
-      BookItem(
-        title: 'Project Hail Mary',
-        author: 'Andy Weir',
-        progress: 0.18,
-        icon: Icons.rocket_launch_outlined,
-      ),
-      BookItem(
-        title: 'Atomic Habits',
-        author: 'James Clear',
-        progress: 0.62,
-        icon: Icons.psychology_alt_outlined,
-      ),
-      BookItem(
-        title: 'Dune',
-        author: 'Frank Herbert',
-        progress: 1,
-        icon: Icons.auto_stories_outlined,
-      ),
-    ];
-
     return BlocProvider(
       create: (context) => getIt<RsvpBloc>(),
       child: BlocBuilder<RsvpBloc, RsvpState>(

--- a/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
+++ b/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
@@ -24,6 +24,7 @@ class MainScreen extends StatelessWidget {
               .map(
                 (b) => BookItem(
                   onTap: () => context.read<RsvpBloc>().add(RsvpEvent.toggleSelectBook(book: b)),
+                  isSelected: state.selectedBook == b,
                   title: b.name ?? 'Unknown',
                   author: 'Unknown',
                   progress: 0.0,

--- a/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
+++ b/lib/features/rsvp_engine/presentation/ui/pages/main_page.dart
@@ -4,33 +4,83 @@ import 'package:rsvp_flutter_app/core/di/di.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/mock_reading_button.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/new_book_button.dart';
+import 'package:rsvp_flutter_app/features/ui_kit/ui_kit.dart';
 
-class MainScreen extends StatefulWidget {
+class MainScreen extends StatelessWidget {
   const MainScreen({super.key});
 
   @override
-  State<MainScreen> createState() => _MainScreenState();
-}
-
-class _MainScreenState extends State<MainScreen> {
-  @override
   Widget build(BuildContext context) {
+    const state = LibraryMainScreenState.nonEmpty;
+    const bookItems = [
+      BookItem(
+        title: 'Project Hail Mary',
+        author: 'Andy Weir',
+        progress: 0.18,
+        icon: Icons.rocket_launch_outlined,
+      ),
+      BookItem(
+        title: 'Atomic Habits',
+        author: 'James Clear',
+        progress: 0.62,
+        icon: Icons.psychology_alt_outlined,
+      ),
+      BookItem(
+        title: 'Dune',
+        author: 'Frank Herbert',
+        progress: 1,
+        icon: Icons.auto_stories_outlined,
+      ),
+    ];
+
     return BlocProvider(
       create: (context) => getIt<RsvpBloc>(),
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('TikTok-book'),
-        ),
-        body: const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(
-            child: Column(
-              children: [
-                NewBookButton(),
-                SizedBox(height: 16),
-                MockReadingButton(),
-              ],
-            ),
+      child: BlocBuilder<RsvpBloc, RsvpState>(
+        builder: (context, state) {
+          final LibraryMainScreenState screenState = switch (state) {
+            _ when state.lastError != null => .importError,
+            _ when state.books.isNotEmpty => .nonEmpty,
+            _ => .empty,
+          };
+
+          final bookWidgets = state.books
+              .map(
+                (b) => BookItem(
+                  title: b.name ?? 'Unknown',
+                  author: 'Unknown',
+                  progress: 0.0,
+                ),
+              )
+              .toList();
+
+          return LibraryMainScreen(
+            state: screenState,
+            bookItems: bookWidgets,
+            onStateActionTap: () => context.read<RsvpBloc>().add(const RsvpEvent.addBook()),
+            onAddBookTap: () => context.read<RsvpBloc>().add(const RsvpEvent.addBook()),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class OldMainPage extends StatelessWidget {
+  const OldMainPage({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('TikTok-book'),
+      ),
+      body: const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Center(
+          child: Column(
+            children: [NewBookButton()],
           ),
         ),
       ),

--- a/lib/features/ui_kit/presentation/ui/widgets/book_item.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/book_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:rsvp_flutter_app/core/constants.dart';
 import 'package:rsvp_flutter_app/core/theme/theme.dart';
 
 class BookItem extends StatelessWidget {
@@ -13,8 +14,8 @@ class BookItem extends StatelessWidget {
     super.key,
   });
 
-  static const Duration _selectionAnimationDuration = Duration(milliseconds: 400);
-  static const Curve _selectionAnimationCurve = Curves.easeInOutCubic;
+  static const Duration _selectionAnimationDuration = Constants.basicAnimationDuration;
+  static const Curve _selectionAnimationCurve = Constants.basicAnimationCurve;
 
   final String title;
   final String author;

--- a/lib/features/ui_kit/presentation/ui/widgets/book_item.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/book_item.dart
@@ -7,15 +7,20 @@ class BookItem extends StatelessWidget {
     required this.author,
     required this.progress,
     this.onTap,
+    this.isSelected = false,
     this.icon = Icons.menu_book_outlined,
     this.finishedLabel = 'FINISHED',
     super.key,
   });
 
+  static const Duration _selectionAnimationDuration = Duration(milliseconds: 400);
+  static const Curve _selectionAnimationCurve = Curves.easeInOutCubic;
+
   final String title;
   final String author;
   final double progress;
   final VoidCallback? onTap;
+  final bool isSelected;
   final IconData icon;
   final String finishedLabel;
 
@@ -25,33 +30,59 @@ class BookItem extends StatelessWidget {
     final isFinished = clampedProgress >= 1;
     final theme = Theme.of(context);
     final appTheme = context.appTheme;
+    final borderRadius = BorderRadius.circular(16);
+    final decoration = isSelected
+        ? BoxDecoration(
+            borderRadius: borderRadius,
+            border: Border.all(
+              color: appTheme.secondaryColor.withValues(alpha: 0.22),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: appTheme.primaryColor.withValues(alpha: 0.1),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+              BoxShadow(
+                color: appTheme.secondaryColor.withValues(alpha: 0.08),
+                blurRadius: 6,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          )
+        : BoxDecoration(
+            color: appTheme.backgroundColor2,
+            borderRadius: borderRadius,
+            boxShadow: [
+              BoxShadow(
+                color: appTheme.stateCardShadowColor,
+                blurRadius: 20,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          );
+    final coverDecoration = BoxDecoration(
+      color: isSelected ? appTheme.backgroundColor2.withValues(alpha: 0.72) : appTheme.backgroundColor,
+      borderRadius: BorderRadius.circular(8),
+    );
 
     return GestureDetector(
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
-      child: Container(
+      child: AnimatedContainer(
+        duration: _selectionAnimationDuration,
+        curve: _selectionAnimationCurve,
         constraints: const BoxConstraints(minHeight: 114),
         padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: appTheme.backgroundColor2,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: appTheme.stateCardShadowColor,
-              blurRadius: 20,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
+        decoration: decoration,
         child: Row(
           children: [
-            Container(
+            AnimatedContainer(
+              duration: _selectionAnimationDuration,
+              curve: _selectionAnimationCurve,
               height: 80,
               width: 64,
-              decoration: BoxDecoration(
-                color: appTheme.backgroundColor,
-                borderRadius: BorderRadius.circular(8),
-              ),
+              decoration: coverDecoration,
               child: Icon(
                 icon,
                 color: appTheme.primaryColor.withValues(alpha: 0.35),

--- a/lib/features/ui_kit/presentation/ui/widgets/bottom_selectedbook_window.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/bottom_selectedbook_window.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/cupertino.dart';
+import 'package:rsvp_flutter_app/core/theme/theme.dart';
+import 'package:rsvp_flutter_app/features/rsvp_engine/domain/book_model.dart';
+
+class BottomSelectedbookWindow extends StatelessWidget {
+  const BottomSelectedbookWindow({required this.selectedBook, super.key});
+
+  final BookMetaModel selectedBook;
+
+  @override
+  Widget build(BuildContext context) {
+    final appTheme = context.appTheme;
+    final title = _resolveTitle(selectedBook);
+    final wordCount = selectedBook.tokens.length;
+    final fileExtension = selectedBook.bookFile.fileExtension.toUpperCase();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: appTheme.backgroundColor2,
+              borderRadius: BorderRadius.circular(24),
+              border: Border.all(
+                color: appTheme.secondaryColor.withValues(alpha: 0.18),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: appTheme.primaryColor.withValues(alpha: 0.12),
+                  blurRadius: 28,
+                  offset: const Offset(0, 14),
+                ),
+                BoxShadow(
+                  color: appTheme.stateCardShadowColor,
+                  blurRadius: 14,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(14, 14, 16, 14),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Selected book',
+                          style: appTheme.subTextStyle.copyWith(
+                            color: appTheme.primaryColor,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0.2,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: appTheme.mainTextStyle.copyWith(
+                            fontSize: 17,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: [
+                            _InfoChip(
+                              label: _wordCountLabel(wordCount),
+                              color: appTheme.primaryColor,
+                            ),
+                            _InfoChip(
+                              label: fileExtension,
+                              color: appTheme.secondaryColor,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: appTheme.primaryColor.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: CupertinoButton(
+                      padding: .zero,
+                      child: Text(
+                        'Read',
+                        style: appTheme.mainTextStyle.copyWith(
+                          color: appTheme.primaryColor,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.2,
+                        ),
+                      ),
+                      onPressed: () {},
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _resolveTitle(BookMetaModel book) {
+    final name = book.name?.trim();
+    if (name != null && name.isNotEmpty) {
+      return name;
+    }
+
+    return book.bookFile.name;
+  }
+
+  String _wordCountLabel(int count) {
+    if (count == 1) {
+      return '1 word';
+    }
+
+    return '$count words';
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.label,
+    required this.color,
+  });
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final appTheme = context.appTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: appTheme.subTextStyle.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/ui_kit/presentation/ui/widgets/bottom_selectedbook_window.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/bottom_selectedbook_window.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
+import 'package:rsvp_flutter_app/core/di/di.dart';
+import 'package:rsvp_flutter_app/core/navigation/navigation_service.dart';
 import 'package:rsvp_flutter_app/core/theme/theme.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/domain/book_model.dart';
 
@@ -101,7 +105,15 @@ class BottomSelectedbookWindow extends StatelessWidget {
                           letterSpacing: 0.2,
                         ),
                       ),
-                      onPressed: () {},
+                      onPressed: () {
+                        final navigationService = getIt<NavigationService>();
+                        unawaited(
+                          navigationService.goToReadingScreen(
+                            tokens: selectedBook.tokens,
+                            bookTitle: 'Демо-книга',
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ],

--- a/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rsvp_flutter_app/core/constants.dart';
 import 'package:rsvp_flutter_app/core/theme/theme.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/new_book_button.dart';
@@ -12,8 +13,8 @@ enum LibraryMainScreenState {
   importError,
 }
 
-const _bookSelectionAnimationDuration = Duration(milliseconds: 400);
-const Curve _bookSelectionAnimationCurve = Curves.easeInOutCubic;
+const Duration _bookSelectionAnimationDuration = Constants.basicAnimationDuration;
+const Curve _bookSelectionAnimationCurve = Constants.basicAnimationCurve;
 
 class LibraryMainScreen extends StatelessWidget {
   const LibraryMainScreen({

--- a/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
@@ -12,6 +12,9 @@ enum LibraryMainScreenState {
   importError,
 }
 
+const _bookSelectionAnimationDuration = Duration(milliseconds: 400);
+const Curve _bookSelectionAnimationCurve = Curves.easeInOutCubic;
+
 class LibraryMainScreen extends StatelessWidget {
   const LibraryMainScreen({
     required this.state,
@@ -96,13 +99,40 @@ class LibraryMainScreen extends StatelessWidget {
               buildWhen: (previous, current) => previous.selectedBook != current.selectedBook,
               builder: (context, state) {
                 final selectedBook = state.selectedBook;
-                if (selectedBook == null) return const SizedBox.shrink();
-
                 return Positioned(
                   left: 0,
                   right: 0,
                   bottom: 32,
-                  child: BottomSelectedbookWindow(selectedBook: selectedBook),
+                  child: AnimatedSwitcher(
+                    duration: _bookSelectionAnimationDuration,
+                    switchInCurve: _bookSelectionAnimationCurve,
+                    switchOutCurve: _bookSelectionAnimationCurve,
+                    transitionBuilder: (child, animation) {
+                      final curvedAnimation = CurvedAnimation(
+                        parent: animation,
+                        curve: _bookSelectionAnimationCurve,
+                      );
+
+                      return FadeTransition(
+                        opacity: curvedAnimation,
+                        child: SlideTransition(
+                          position: Tween<Offset>(
+                            begin: const Offset(0, 0.08),
+                            end: Offset.zero,
+                          ).animate(curvedAnimation),
+                          child: child,
+                        ),
+                      );
+                    },
+                    child: selectedBook == null
+                        ? const SizedBox(
+                            key: ValueKey('bottom-selected-book-empty'),
+                          )
+                        : BottomSelectedbookWindow(
+                            key: ValueKey(selectedBook.bookFile.name),
+                            selectedBook: selectedBook,
+                          ),
+                  ),
                 );
               },
             ),

--- a/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
@@ -146,14 +146,22 @@ class LibraryMainScreen extends StatelessWidget {
   Widget _buildBody(BuildContext context) {
     switch (state) {
       case LibraryMainScreenState.nonEmpty:
-        return ListView(
+        return Column(
           children: [
             NewBookButton(
               label: addBookLabel,
               onTap: onAddBookTap,
             ),
             const SizedBox(height: 18),
-            ..._buildSeparatedItems(bookItems),
+            Expanded(
+              child: ListView(
+                children: [
+                  ..._buildSeparatedItems(bookItems),
+                  // Also add sizedBox for valid intersection with bottom_selectedbook_window.
+                  const SizedBox(height: 200),
+                ],
+              ),
+            ),
           ],
         );
       case LibraryMainScreenState.empty:

--- a/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
@@ -78,15 +78,6 @@ class LibraryMainScreen extends StatelessWidget {
                       style: appTheme.titleTextStyle,
                     ),
                     const SizedBox(height: 18),
-                    Container(
-                      width: 44,
-                      height: 4,
-                      decoration: BoxDecoration(
-                        color: appTheme.secondaryColor,
-                        borderRadius: BorderRadius.circular(999),
-                      ),
-                    ),
-                    const SizedBox(height: 18),
                     Expanded(
                       child: _buildBody(context),
                     ),

--- a/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/library_main_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rsvp_flutter_app/core/theme/theme.dart';
+import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart';
 import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/ui/widgets/new_book_button.dart';
+import 'package:rsvp_flutter_app/features/ui_kit/presentation/ui/widgets/bottom_selectedbook_window.dart';
 import 'package:rsvp_flutter_app/features/ui_kit/presentation/ui/widgets/primary_button.dart';
 
 enum LibraryMainScreenState {
@@ -49,41 +52,59 @@ class LibraryMainScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: appTheme.backgroundColor2,
       body: SafeArea(
-        child: Column(
+        child: Stack(
           children: [
-            Container(
-              height: 68,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: appTheme.backgroundColor2,
-                border: Border(
-                  bottom: BorderSide(
-                    color: appTheme.dividerColorMuted,
+            Column(
+              children: [
+                Container(
+                  height: 68,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: appTheme.backgroundColor2,
+                    border: Border(
+                      bottom: BorderSide(
+                        color: appTheme.dividerColorMuted,
+                      ),
+                    ),
+                  ),
+                  child: Text(
+                    appBarTitle,
+                    style: appBarTextStyle,
                   ),
                 ),
-              ),
-              child: Text(
-                appBarTitle,
-                style: appBarTextStyle,
-              ),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 22, 16, 24),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      collectionTitle,
-                      style: appTheme.titleTextStyle,
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 22, 16, 24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          collectionTitle,
+                          style: appTheme.titleTextStyle,
+                        ),
+                        const SizedBox(height: 18),
+                        Expanded(
+                          child: _buildBody(context),
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 18),
-                    Expanded(
-                      child: _buildBody(context),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
+              ],
+            ),
+            BlocBuilder<RsvpBloc, RsvpState>(
+              buildWhen: (previous, current) => previous.selectedBook != current.selectedBook,
+              builder: (context, state) {
+                final selectedBook = state.selectedBook;
+                if (selectedBook == null) return const SizedBox.shrink();
+
+                return Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 32,
+                  child: BottomSelectedbookWindow(selectedBook: selectedBook),
+                );
+              },
             ),
           ],
         ),

--- a/lib/features/ui_kit/presentation/ui/widgets/primary_button.dart
+++ b/lib/features/ui_kit/presentation/ui/widgets/primary_button.dart
@@ -20,7 +20,8 @@ class PrimaryButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appTheme = context.appTheme;
-    final buttonTextColor = appTheme.buttonTextStyle.color;
+    // final buttonTextColor = appTheme.buttonTextStyle.color;
+    const buttonTextColor = Colors.white;
 
     return Semantics(
       button: true,
@@ -51,9 +52,10 @@ class PrimaryButton extends StatelessWidget {
                     const SizedBox(width: 10),
                     Flexible(
                       child: Text(
+                        // TODO: add theme for this text.
                         text,
                         overflow: TextOverflow.ellipsis,
-                        style: appTheme.buttonTextStyle,
+                        style: appTheme.buttonTextStyle.copyWith(color: buttonTextColor),
                       ),
                     ),
                   ],

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		4305652D4AB99629AC1BBAD1 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FA9FA8E8FD44A192A7AE1AA /* Pods_Runner.framework */; };
+		867AFB001649209DB4A4C4FE /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18C720DBC8D3D164740B7E65 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		18C720DBC8D3D164740B7E65 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		274B065512A055A54FD21297 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* rsvp_flutter_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "rsvp_flutter_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* rsvp_flutter_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = rsvp_flutter_app.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		508347BBD874A300F88A9567 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		5A1EF1812FC3B14847CFD2BD /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		759D6BB9C3760B15EEB13AC6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7FA9FA8E8FD44A192A7AE1AA /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		A1E8F73BDBA1595186FA31E3 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		C60A62A877A1A9A1799B002E /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				867AFB001649209DB4A4C4FE /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4305652D4AB99629AC1BBAD1 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				FB149A5599C091BC6443921B /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,8 +188,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7FA9FA8E8FD44A192A7AE1AA /* Pods_Runner.framework */,
+				18C720DBC8D3D164740B7E65 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FB149A5599C091BC6443921B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				759D6BB9C3760B15EEB13AC6 /* Pods-Runner.debug.xcconfig */,
+				A1E8F73BDBA1595186FA31E3 /* Pods-Runner.release.xcconfig */,
+				274B065512A055A54FD21297 /* Pods-Runner.profile.xcconfig */,
+				C60A62A877A1A9A1799B002E /* Pods-RunnerTests.debug.xcconfig */,
+				5A1EF1812FC3B14847CFD2BD /* Pods-RunnerTests.release.xcconfig */,
+				508347BBD874A300F88A9567 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				475E8370913A69E40BE4EE63 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				F76D93F29B596DF8FCBEB3D5 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				EC8C2A8233F0A6B63472078B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		475E8370913A69E40BE4EE63 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EC8C2A8233F0A6B63472078B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F76D93F29B596DF8FCBEB3D5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C60A62A877A1A9A1799B002E /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5A1EF1812FC3B14847CFD2BD /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 508347BBD874A300F88A9567 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/test/features/rsvp_engine/presentation/state/bloc/rsvp_bloc_test.dart
+++ b/test/features/rsvp_engine/presentation/state/bloc/rsvp_bloc_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rsvp_flutter_app/features/file_picking/domain/entities/book_file.dart';
+import 'package:rsvp_flutter_app/features/file_picking/domain/repositories/file_repository.dart';
+import 'package:rsvp_flutter_app/features/rsvp_engine/domain/book_model.dart';
+import 'package:rsvp_flutter_app/features/rsvp_engine/presentation/state/bloc/rsvp_bloc.dart';
+import 'package:rsvp_flutter_app/services/book_converter.dart';
+import 'package:rsvp_flutter_app/services/pdf_parser.dart';
+import 'package:rsvp_flutter_app/services/text_processor.dart';
+import 'package:rsvp_flutter_app/services/txt_parser.dart';
+
+void main() {
+  group('RsvpBloc toggleSelectBook', () {
+    late RsvpBloc bloc;
+
+    setUp(() {
+      bloc = RsvpBloc(
+        fileRepository: _FakeFileRepository(),
+        bookConverter: _FakeBookConverter(),
+      );
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    test('selects a book when nothing is selected', () async {
+      final book = _buildBook(name: 'Book one');
+
+      final nextState = expectLater(
+        bloc.stream,
+        emits(
+          isA<RsvpState>().having(
+            (state) => state.selectedBook,
+            'selectedBook',
+            book,
+          ),
+        ),
+      );
+
+      bloc.add(RsvpEvent.toggleSelectBook(book: book));
+
+      await nextState;
+    });
+
+    test('deselects a book when the same book is toggled twice', () async {
+      final book = _buildBook(name: 'Book one');
+
+      final nextStates = expectLater(
+        bloc.stream,
+        emitsInOrder([
+          isA<RsvpState>().having(
+            (state) => state.selectedBook,
+            'selectedBook',
+            book,
+          ),
+          isA<RsvpState>().having(
+            (state) => state.selectedBook,
+            'selectedBook',
+            isNull,
+          ),
+        ]),
+      );
+
+      bloc
+        ..add(RsvpEvent.toggleSelectBook(book: book))
+        ..add(RsvpEvent.toggleSelectBook(book: book));
+
+      await nextStates;
+    });
+
+    test('replaces the selection when another book is toggled', () async {
+      final firstBook = _buildBook(name: 'Book one');
+      final secondBook = _buildBook(name: 'Book two');
+
+      final nextStates = expectLater(
+        bloc.stream,
+        emitsInOrder([
+          isA<RsvpState>().having(
+            (state) => state.selectedBook,
+            'selectedBook',
+            firstBook,
+          ),
+          isA<RsvpState>().having(
+            (state) => state.selectedBook,
+            'selectedBook',
+            secondBook,
+          ),
+        ]),
+      );
+
+      bloc
+        ..add(RsvpEvent.toggleSelectBook(book: firstBook))
+        ..add(RsvpEvent.toggleSelectBook(book: secondBook));
+
+      await nextStates;
+    });
+  });
+}
+
+BookMetaModel _buildBook({required String name}) {
+  final file = File('/tmp/${name.toLowerCase().replaceAll(' ', '_')}.txt');
+
+  return BookMetaModel(
+    bookFile: BookFile(
+      name: name,
+      path: file.path,
+      fileExtension: 'txt',
+      size: 1,
+      file: file,
+    ),
+  );
+}
+
+class _FakeFileRepository implements FileRepository {
+  @override
+  Future<BookFile?> loadFileFromLocal(String path) async => null;
+
+  @override
+  Future<BookFile?> pickAndLoadFile() async => null;
+
+  @override
+  Future<void> saveFile(BookFile bf) async {}
+}
+
+class _FakeBookConverter extends BookConverter {
+  _FakeBookConverter()
+    : super(
+        _FakePdfParser(),
+        _FakeTxtParser(),
+        _FakeTextProcessor(),
+      );
+}
+
+class _FakePdfParser extends PdfParser {
+  @override
+  Future<String> parse(File file) async => '';
+}
+
+class _FakeTxtParser extends TxtParser {
+  @override
+  Future<String> parse(File file) async => '';
+}
+
+class _FakeTextProcessor extends TextProcessor {
+  @override
+  List<String> process(String text) => const [];
+}


### PR DESCRIPTION
## Summary

Wire the library UI into `RsvpBloc` so imported books are kept in state, can be selected from the library list, and can be opened from a new bottom action panel.

## Changes

- Replace the old `MainScreen` flow with a `BlocProvider`/`BlocBuilder` setup that drives `LibraryMainScreen` from `RsvpState`.
- Extend `RsvpBloc` state and events to store a `books` list, rename the parsing error field to `lastError`, and support selecting/deselecting a book with `toggleSelectBook`.
- Update the add-book flow to append parsed books to the library instead of only setting a single selected book.
- Add some animations and UI tweaks